### PR TITLE
Urlencode account name in otpauth URL

### DIFF
--- a/drivers/GoogleAuthenticatorDriver.php
+++ b/drivers/GoogleAuthenticatorDriver.php
@@ -143,7 +143,7 @@ class GoogleAuthenticatorDriver extends BaseDriver
         }
 
         return $this->renderFile([
-            'qrCodeText' => 'otpauth://totp/' . Yii::$app->request->hostName . ':' . TwofaHelper::getAccountName() . '?secret=' . $secret . '&issuer=' . Yii::$app->request->hostName,
+            'qrCodeText' => 'otpauth://totp/' . Yii::$app->request->hostName . ':' . urlencode(TwofaHelper::getAccountName()) . '?secret=' . $secret . '&issuer=' . Yii::$app->request->hostName,
             'secret' => $secret,
             'requirePinCode' => $requirePinCode,
         ], ['suffix' => 'Code']);

--- a/drivers/GoogleAuthenticatorDriver.php
+++ b/drivers/GoogleAuthenticatorDriver.php
@@ -143,7 +143,7 @@ class GoogleAuthenticatorDriver extends BaseDriver
         }
 
         return $this->renderFile([
-            'qrCodeText' => 'otpauth://totp/' . Yii::$app->request->hostName . ':' . urlencode(TwofaHelper::getAccountName()) . '?secret=' . $secret . '&issuer=' . Yii::$app->request->hostName,
+            'qrCodeText' => 'otpauth://totp/' . Yii::$app->request->hostName . ':' . rawurlencode(TwofaHelper::getAccountName()) . '?secret=' . $secret . '&issuer=' . Yii::$app->request->hostName,
             'secret' => $secret,
             'requirePinCode' => $requirePinCode,
         ], ['suffix' => 'Code']);


### PR DESCRIPTION
The HumHub username can contain UTF-8 characters, and in our case it does. However qrcode.js cannot handle that
and won't render the qr code at all. Only output would be an exception in the JS-Console.

This Commit wraps the account name with urlencode to fix that issue.