### PR TITLE
Fix infinite redirect loop when another module intercepts the current action

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -12,6 +12,7 @@ use humhub\helpers\ControllerHelper;
 use humhub\modules\admin\controllers\UserController as AdminUserController;
 use humhub\modules\admin\grid\UserActionColumn;
 use humhub\modules\admin\permissions\ManageUsers;
+use humhub\modules\twofa\controllers\CheckController;
 use humhub\modules\twofa\events\BeforeCheck;
 use humhub\modules\twofa\helpers\TwofaHelper;
 use humhub\modules\twofa\helpers\TwofaUrl;
@@ -58,7 +59,7 @@ class Events
     public static function onBeforeAction($event)
     {
         if (Yii::$app->user->mustChangePassword()) {
-            return false;
+            return;
         }
 
         /** @var Controller $controller */
@@ -68,20 +69,52 @@ class Events
             Yii::$app->session->set('twofa.switchedUserId', Yii::$app->user->id);
         }
 
-        if (
-            $controller->module->id === 'fcm-push'
-            && $controller->id === 'token'
-            && $controller->action->id === 'update'
-        ) {
-            return false;
+        // Another event handler (e.g. from a module intercepting the same action) has
+        // already canceled or redirected the current action; overriding its redirect
+        // could produce a redirect loop between the two modules
+        if (!$event->isValid || Yii::$app->response->getIsRedirection()) {
+            return;
+        }
+
+        // Twofa-own allowlist — deliberately NOT the generic $doNotInterceptActionIds
+        // flag: that flag is set by controllers for unrelated reasons (e.g. the REST
+        // module, live polling, account deletion) and honoring it would exempt those
+        // actions from the second factor. Every entry here is a security decision.
+        if (self::isTwofaExemptRoute($controller, $event)) {
+            return;
         }
 
         $beforeVerifying = new BeforeCheck();
         Yii::$app->trigger($beforeVerifying->name, $beforeVerifying);
 
-        if (!$beforeVerifying->handled && TwofaHelper::isVerifyingRequired() && !Yii::$app->getModule('twofa')->isTwofaCheckUrl()) {
-            return Yii::$app->response->redirect(TwofaUrl::toCheck());
+        if (!$beforeVerifying->handled && TwofaHelper::isVerifyingRequired()) {
+            $event->isValid = false;
+            Yii::$app->response->redirect(TwofaUrl::toCheck());
         }
+    }
+
+    /**
+     * Routes that stay reachable while the two-factor verification is pending.
+     *
+     * @param $controller Controller
+     * @return bool
+     */
+    protected static function isTwofaExemptRoute($controller, $event): bool
+    {
+        // The 2fa check page itself — redirecting it would loop onto itself
+        if ($controller instanceof CheckController) {
+            return true;
+        }
+
+        // Login and logout must stay reachable
+        if ($controller instanceof AuthController) {
+            return true;
+        }
+
+        // The mobile app updates its push token in the background
+        return $controller->module->id === 'fcm-push'
+            && $controller->id === 'token'
+            && $event->action->id === 'update';
     }
 
     /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.2.3 (Unreleased)
+------------------
+- Fix: Infinite redirect loop to the 2FA check page when another module intercepts the current action — the handler now yields when another interceptor already redirected the request, cancels the action via `$event->isValid` and uses a twofa-own, security-reviewed exemption list (check page, login/logout, push token update) instead of a generic opt-out flag
+
 1.2.2 (June 18, 2026)
 ---------------------
 - Enh: Automated code refactoring for HumHub 1.18.0-beta.6 using Rector

--- a/module.json
+++ b/module.json
@@ -14,7 +14,7 @@
         "resources/screenshot3.png",
         "resources/screenshot4.png"
     ],
-    "version": "1.2.2",
+    "version": "1.2.3",
     "humhub": {
         "minVersion": "1.18.0-beta.6",
         "maxVersion": "1.18"


### PR DESCRIPTION
Supersedes #117 — same loop fix, without widening the 2FA bypass surface.

## The loop fix (as in #117)

- The intercepted action is canceled via `$event->isValid = false` (returning `false` from an event handler has no effect — previously the action still ran and only the `Location` header enforced the redirect).
- The handler yields when another interceptor already canceled or redirected the request, so two intercepting modules no longer overwrite each other's redirects (humhub-internal#1261).

## The difference to #117

#117 additionally honored the generic `Controller::$doNotInterceptActionIds` flag. That flag is set by controllers for unrelated reasons, so honoring it in twofa silently exempts those actions from the second factor while verification is pending:

- `user/account/delete` (`['delete']`) — account deletion only requires the **current password**, which is exactly what an attacker in the 2FA threat model already has: a password thief could destructively delete the account without ever passing 2FA
- `live/poll/*` (`['*']`) — notification/activity data delivered to an unverified session
- `rest` (`['*']`) — the whole REST API
- plus any third-party controller that adopts the flag in the future for e.g. legal reasons

This PR instead uses a **twofa-own, security-reviewed exemption list**: the check page itself (self-loop protection), `AuthController` (login/logout — logout was previously unreachable while pending), and the fcm-push token update. Everything else — including the routes above — stays behind the second factor, exactly as in 1.2.2.

For the 1.19 line, the module moves to the core user gate system entirely (#118 / humhub/humhub#8291), which solves the cross-module ordering structurally.
