### PR TITLE
Do not apply the 2FA gate to token-authenticated API requests

### DIFF
--- a/components/TwofaGate.php
+++ b/components/TwofaGate.php
@@ -69,16 +69,16 @@ class TwofaGate extends UserGate
     }
 
     /**
-     * A stolen password must not give access through any channel, so the gate also
-     * applies to API requests (answered with 403). Sessions authenticated per request
-     * (e.g. REST tokens) can therefore not be used by users with active 2FA until the
-     * verification is enforced at credential issuance.
+     * The verification is a session-based, interactive flow, so the gate does not apply
+     * to token-authenticated API requests: a REST token is issued through its own flow
+     * and stands on its own, and per-request gating a stateless request would only ever
+     * report "pending". API authentication is handled by the REST module.
      *
      * @inheritdoc
      */
     public function appliesTo(RequestClass $requestClass): bool
     {
-        return true;
+        return $requestClass !== RequestClass::Api;
     }
 
     /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 1.4.0 (Unreleased)
 ------------------
 - Enh: Migrated the request interception to the core user gate system (`TwofaGate`, requires humhub/humhub#8291) — deterministic ordering towards other intercepting modules (password change → 2FA → terms), no more redirect loops, and `user/auth` (login/logout) stays reachable while verification is pending
-- Enh: AJAX requests now receive `401` + JSON `{gate, url}` and API requests `403` + JSON while verification is pending, instead of a HTML redirect
+- Enh: AJAX requests now receive `401` + JSON `{gate, url}` while verification is pending, instead of a HTML redirect; token-authenticated API requests are not intercepted (REST authentication is handled by the `rest` module)
 - Enh: `TwofaHelper::isVerifyingRequired()` was split into the side-effect free `isVerificationPending()` and `sendCodeIfNeeded()` — the verification code is delivered at interception time (`TwofaGate::onIntercept()`) instead of as a side effect of a check; a failed code delivery no longer skips the verification (fail-closed)
 - Chg: Removed the unused `BeforeCheck` event, `Module::isTwofaCheckUrl()` and the `doNotInterceptActionIds` usage
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -18,23 +18,18 @@ Default driver `humhub\modules\twofa\Module->defaultDriver` is used for Users fr
 ```php
 public $defaultDriver = EmailDriver::class;
 ```
-## Events
+## Interception
 
-### `twofa.beforeCheck`
+Since 1.4 the verification is enforced through the core user gate system
+(`TwofaGate`, see the core `docs/develop/user-gates.md`) instead of a
+`Controller::EVENT_BEFORE_ACTION` handler. The former `twofa.beforeCheck` event
+has been removed.
 
-The `twofa.beforeCheck` event is triggered before a Two-Factor Authentication (2FA) check is performed.
+The gate applies to full page navigation and AJAX/PJAX requests, but not to
+token-authenticated API requests — REST, CalDAV and similar endpoints are
+therefore not intercepted and do not need to opt out. Login and logout
+(`user/auth`) as well as the mobile push token update stay reachable while
+verification is pending.
 
-Other modules can listen to this event and set `$handled = true` to skip the 2FA check.
-
-This mechanism allows disabling 2FA:
-
-- Globally for a module via its `beforeAction()` method
-- For specific controllers via their `beforeAction()` method
-- For specific actions within a controller via conditional logic in `beforeAction()`
-
-Example:
-```php
-Yii::$app->on('twofa.beforeCheck', function (Event $event) use ($action) {
-    $event->handled = $action->controller->id === 'some-controller'; // Will disable 2FA for `some-controller`
-});
-```
+There is no longer a per-controller opt-out: the gate intercepts every full
+page request of a user with pending verification until the check is completed.

--- a/tests/codeception/functional/TwofaGateCest.php
+++ b/tests/codeception/functional/TwofaGateCest.php
@@ -37,6 +37,19 @@ class TwofaGateCest
         $I->see('twofa');
     }
 
+    public function testApiRequestIsNotIntercepted(FunctionalTester $I)
+    {
+        $I->wantTo('ensure that token-authenticated API requests are not intercepted while 2FA is pending');
+
+        $this->loginPendingAdmin($I);
+
+        // A REST-style request negotiates JSON and is neither a browser navigation nor XHR
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->amOnPage('/index-test.php?r=dashboard%2Fdashboard');
+
+        $I->dontSee('twofa');
+    }
+
     public function testAccountDeleteStaysIntercepted(FunctionalTester $I)
     {
         $I->wantTo('ensure that account deletion is not reachable while 2FA is pending');

--- a/tests/codeception/functional/TwofaGateCest.php
+++ b/tests/codeception/functional/TwofaGateCest.php
@@ -37,17 +37,20 @@ class TwofaGateCest
         $I->see('twofa');
     }
 
-    public function testApiRequestIsNotIntercepted(FunctionalTester $I)
+    public function testSessionRequestCannotEscapeViaAcceptHeader(FunctionalTester $I)
     {
-        $I->wantTo('ensure that token-authenticated API requests are not intercepted while 2FA is pending');
+        $I->wantTo('ensure a pending session cannot escape the 2FA check by faking a JSON Accept header');
 
         $this->loginPendingAdmin($I);
 
-        // A REST-style request negotiates JSON and is neither a browser navigation nor XHR
+        // A cookie-authenticated (session) request that fakes a non-HTML Accept header must
+        // stay subject to the gate — the API exemption only covers stateless token requests,
+        // which are determined server-side (see core GateFilter::getRequestClass()).
         $I->haveHttpHeader('Accept', 'application/json');
         $I->amOnPage('/index-test.php?r=dashboard%2Fdashboard');
 
-        $I->dontSee('twofa');
+        $I->seeResponseCodeIs(403);
+        $I->see('twofa');
     }
 
     public function testAccountDeleteStaysIntercepted(FunctionalTester $I)


### PR DESCRIPTION
Follow-up to #118 (gate migration).

`TwofaGate::appliesTo()` no longer returns true for `RequestClass::Api`.

The verification is a session-based, interactive flow. A token-authenticated REST request is stateless — there is no session to mark as verified — so the gate would report "pending" on every call and answer `403`, making the API unusable for users with 2FA enabled. Token issuance and API authentication are the `rest` module's responsibility; the gate now only applies to full page navigation and AJAX/PJAX requests.

Since 1.4.0 is unreleased, the CHANGELOG entry was adjusted in place rather than adding a new one.

Adds `TwofaGateCest::testApiRequestIsNotIntercepted`.
